### PR TITLE
Add setup script and Solidity guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Codex Agent Instructions
+
+## General Workflow
+- Always run `./setup.sh` before executing any tests or scripts.
+- After code changes inside any `challenge-*` directory, run `yarn lint` and `yarn test` in that challenge's root.
+
+## Solidity Best Practices
+- Use `pragma solidity ^0.8.20;` at the top of contracts.
+- Prefer `uint256` over `uint` and specify visibility for all functions and state variables.
+- Use events for significant state changes and emit them where appropriate.
+- Validate inputs with `require` and consider custom errors to save gas.
+- Mark variables `constant` or `immutable` when possible.
+- Avoid unbounded loops and external calls before state changes.
+- Document public and external functions using NatSpec comments.
+
+## Commit Guidance
+- Provide descriptive commit messages explaining the reason for each change.
+- If a decision requires explanation, add brief inline comments in the code or include details in the commit message.

--- a/README.MD
+++ b/README.MD
@@ -117,7 +117,7 @@ Create a dynamic SVG NFT using a smart contract. Your contract will generate on-
 
 2. **Setup**:
    - Clone this repository
-   - Install dependencies for each challenge
+   - Run `./setup.sh` to install all dependencies
    - Follow the specific instructions in each challenge folder
 
 3. **Learning Path**:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enable yarn via corepack (required for workspace builds)
+corepack enable >/dev/null
+
+for dir in challenge-*; do
+    if [ -d "$dir" ] && [ -f "$dir/package.json" ]; then
+        echo "Installing dependencies in $dir"
+        (cd "$dir" && yarn install --frozen-lockfile)
+    fi
+done


### PR DESCRIPTION
## Summary
- introduce `setup.sh` for installing package dependencies
- add `AGENTS.md` with Solidity best practices and workflow guidance
- document running `setup.sh` in main README

## Testing
- `./setup.sh` *(fails: lockfile not created)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685449cfe0508330925abd9d0f8adfa0